### PR TITLE
Change naming

### DIFF
--- a/src/lexer.py
+++ b/src/lexer.py
@@ -1,4 +1,5 @@
-from src.tokens import Tokens, Token, lookupIdent
+from src.tokens import Tokens, Token, lookup_ident
+
 
 class Lexer:
     tokens = {
@@ -7,99 +8,98 @@ class Lexer:
         "[": Token(Tokens.OPBRACKET, "["),
         "]": Token(Tokens.CLBRACKET, "]"),
         ":": Token(Tokens.COLON, ":"),
-        ",": Token(Tokens.COMMA, ",")
+        ",": Token(Tokens.COMMA, ","),
     }
 
     def __init__(self, input):
         self.input = input
         self.pos = 0
-        self.nextPos = 0
+        self.next_pos = 0
         self.ch = None
 
-        self._readChar()
+        self.__read_char()
 
-    def _readChar(self):
-        if self.nextPos >= len(self.input):
+    def __read_char(self):
+        if self.next_pos >= len(self.input):
             self.ch = None
             return
 
-        self.pos = self.nextPos
+        self.pos = self.next_pos
         self.ch = self.input[self.pos]
-        self.nextPos += 1
+        self.next_pos += 1
 
-    def _isText(self, ch):
+    def __is_text(self, ch):
         return ch != '"' and ch != "\n"
 
-    def _isIdent(self, ch):
+    def __is_ident(self, ch):
         return ch in "abcdefghijklmniopqrstuvwxyz"
 
-    def _isDigit(self, ch):
+    def __is_digit(self, ch):
         return ch in "0123456789."
 
-    def _getText(self):
-        self._readChar()
+    def __get_text(self):
+        self.__read_char()
         pos = self.pos
 
-        while self._isText(self.ch):
-            self._readChar()
+        while self.__is_text(self.ch):
+            self.__read_char()
 
-        text = self.input[pos:self.pos]
-        self._readChar()
+        text = self.input[pos : self.pos]
+        self.__read_char()
 
         return text
 
-    def _getIdent(self):
+    def __get_ident(self):
         pos = self.pos
 
-        while self._isIdent(self.ch):
-            self._readChar()
+        while self.__is_ident(self.ch):
+            self.__read_char()
 
-        ident = self.input[pos:self.pos]
+        ident = self.input[pos : self.pos]
 
         return ident
 
-    def _getDigit(self):
+    def __get_digit(self):
         pos = self.pos
 
-        while self._isDigit(self.ch):
-            self._readChar()
+        while self.__is_digit(self.ch):
+            self.__read_char()
 
-        digit = self.input[pos:self.pos]
+        digit = self.input[pos : self.pos]
 
         return digit
 
-    def _eatWhitespace(self):
+    def __eat_whitespace(self):
         while self.ch in [" ", "\n", "\t", "\r"]:
-            self._readChar()
+            self.__read_char()
 
-    def nextToken(self):
-        self._eatWhitespace()
+    def next_token(self):
+        self.__eat_whitespace()
 
         ch = self.ch
-        tok = Token(Tokens.INVALID, None)
 
-        if ch in Lexer.tokens:
+        if ch is None:
+            tok = Token(Tokens.EOF, "")
+
+        elif ch in Lexer.tokens:
             tok = Lexer.tokens[ch]
 
         elif ch == '"':
-            tok = Token(Tokens.STRING, self._getText())
+            tok = Token(Tokens.STRING, self.__get_text())
             return tok
 
-        elif ( not ch is None ) and self._isDigit(self.ch):
-            digit = self._getDigit()
-
-            tok = Token(Tokens.NUMBER, digit)
+        elif self.__is_digit(self.ch):
+            tok = Token(Tokens.NUMBER, self.__get_digit())
             return tok
 
-        elif ( not ch is None ) and self._isIdent(self.ch):
-            ident = self._getIdent()
+        elif self.__is_ident(self.ch):
+            ident = self.__get_ident()
 
-            tok = Token(lookupIdent(ident), ident)
+            tok = Token(lookup_ident(ident), ident)
             return tok
 
-        elif ch is None:
-            tok = Token(Tokens.EOF, "")
+        else:
+            tok = Token(Tokens.INVALID, None)
 
-        self._readChar()
+        self.__read_char()
         return tok
-

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,84 +1,100 @@
 from src.tokens import Tokens
 
+
 class Parser:
     def __init__(self, lex):
         self.lex = lex
         self.errors = []
 
-        self.currToken = None
-        self.peekToken = None
+        self.curr_token = None
+        self.peek_token = None
 
-        self._nextToken()
-        self._nextToken()
+        self.__next_token()
+        self.__next_token()
 
-    def _addError(self, error):
+    def __add_error(self, error):
         self.errors.append(error)
 
-    def _currTokenIs(self, tk): return self.currToken.type == tk
-    def _peekTokenIs(self, tk): return self.peekToken.type == tk
-    def _expectPeek(self, tk):
-        if self._peekTokenIs(tk):
-            self._nextToken()
+    def __curr_token_is(self, tk):
+        return self.curr_token.type == tk
+
+    def __peek_token_is(self, tk):
+        return self.peek_token.type == tk
+
+    def __expect_peek(self, tk):
+        if self.__peek_token_is(tk):
+            self.__next_token()
             return True
 
-        self._addError(f"Expect {tk}, got={self.peekToken.type}")
+        self.__add_error(f"Expect {tk}, got={self.peek_token.type}")
         return False
 
-    def _nextToken(self):
-        self.currToken = self.peekToken
-        self.peekToken = self.lex.nextToken()
+    def __next_token(self):
+        self.curr_token = self.peek_token
+        self.peek_token = self.lex.next_token()
 
-    def _parseObject(self):
+    def __parse_object(self):
         obj = {}
 
-        while not self._currTokenIs(Tokens.CLBRACE) and not self._currTokenIs(Tokens.EOF):
-            if not self._expectPeek(Tokens.STRING): return None
+        while not self.__curr_token_is(Tokens.CLBRACE) and not self.__curr_token_is(
+            Tokens.EOF
+        ):
+            if not self.__expect_peek(Tokens.STRING):
+                return None
 
-            key = self.currToken.literal
+            key = self.curr_token.literal
 
-            if not self._expectPeek(Tokens.COLON): return None
+            if not self.__expect_peek(Tokens.COLON):
+                return None
 
-            self._nextToken()
+            self.__next_token()
 
-            obj[key] = self._parse()
+            obj[key] = self.__parse()
 
-            self._nextToken()
+            self.__next_token()
 
         return obj
 
-    def _parseArray(self):
+    def __parse_array(self):
         arr = []
 
-        self._nextToken()
+        self.__next_token()
 
-        while not self._currTokenIs(Tokens.CLBRACKET) and not self._currTokenIs(Tokens.EOF):
-            if self._currTokenIs(Tokens.COMMA) and self._peekTokenIs(Tokens.CLBRACKET):
-                self._addError(f"Expected value, got=CLBRACKET")
+        while not self.__curr_token_is(Tokens.CLBRACKET) and not self.__curr_token_is(
+            Tokens.EOF
+        ):
+            if self.__curr_token_is(Tokens.COMMA) and self.__peek_token_is(
+                Tokens.CLBRACKET
+            ):
+                self.__add_error("Expected value, got=CLBRACKET")
                 return None
 
-            elif self._currTokenIs(Tokens.COMMA):
-                self._nextToken()
+            elif self.__curr_token_is(Tokens.COMMA):
+                self.__next_token()
                 continue
 
-            element = self._parse()
+            element = self.__parse()
             arr.append(element)
 
-            self._nextToken()
+            self.__next_token()
 
         return arr
 
-    def _parse(self):
-        tok = self.currToken
+    def __parse(self):
+        tok = self.curr_token
 
-        if self._currTokenIs(Tokens.TRUE): return True
-        elif self._currTokenIs(Tokens.FALSE): return False
-        elif self._currTokenIs(Tokens.STRING): return tok.literal
-        elif self._currTokenIs(Tokens.OPBRACE):
-            return self._parseObject()
-        elif self._currTokenIs(Tokens.OPBRACKET):
-            return self._parseArray()
-        elif self._currTokenIs(Tokens.NUMBER): return float(tok.literal)
+        if self.__curr_token_is(Tokens.TRUE):
+            return True
+        elif self.__curr_token_is(Tokens.FALSE):
+            return False
+        elif self.__curr_token_is(Tokens.STRING):
+            return tok.literal
+        elif self.__curr_token_is(Tokens.OPBRACE):
+            return self.__parse_object()
+        elif self.__curr_token_is(Tokens.OPBRACKET):
+            return self.__parse_array()
+        elif self.__curr_token_is(Tokens.NUMBER):
+            return float(tok.literal)
 
     def parse(self):
-        return self._parse()
-
+        return self.__parse()

--- a/src/tokens.py
+++ b/src/tokens.py
@@ -1,37 +1,35 @@
 from enum import Enum
 from dataclasses import dataclass
 
+
 class Tokens(Enum):
     INVALID = "INVALID"
-    EOF     = "EOF"
+    EOF = "EOF"
 
-    OPBRACE   = "OPBRACE"
-    CLBRACE   = "CLBRACE"
+    OPBRACE = "OPBRACE"
+    CLBRACE = "CLBRACE"
     OPBRACKET = "OPBRACKET"
     CLBRACKET = "CLBRACKET"
-    COMMA     = "COMMA"
-    COLON     = "COLON"
+    COMMA = "COMMA"
+    COLON = "COLON"
 
-
-    TRUE   = "TRUE"
-    FALSE  = "FALSE"
+    TRUE = "TRUE"
+    FALSE = "FALSE"
     STRING = "STRING"
     NUMBER = "NUMBER"
-
-keywords = {
-    "true": Tokens.TRUE,
-    "false": Tokens.FALSE
-}
-
-
-def lookupIdent(ident):
-    if ident in keywords:
-        return keywords[ident]
-
-    return ident
 
 
 @dataclass
 class Token:
     type: Tokens
     literal: str
+
+
+keywords = {"true": Tokens.TRUE, "false": Tokens.FALSE}
+
+
+def lookup_ident(ident):
+    if ident in keywords:
+        return keywords[ident]
+
+    return ident

--- a/tests/lexer_test.py
+++ b/tests/lexer_test.py
@@ -3,49 +3,50 @@ import unittest
 from src.tokens import Tokens
 from src.lexer import Lexer
 
+
 class LexerTesting(unittest.TestCase):
     def test_tokenization(self):
         json = '{"foo":"bar", "num": 12, "bool": false, "obj": { "inner": "obj" }, "arr": ["first", 12, true]}'
 
         tokens = [
-                (Tokens.OPBRACE, "{"),
-                (Tokens.STRING, "foo"),
-                (Tokens.COLON, ":"),
-                (Tokens.STRING, "bar"),
-                (Tokens.COMMA, ","),
-                (Tokens.STRING, "num"),
-                (Tokens.COLON, ":"),
-                (Tokens.NUMBER, "12"),
-                (Tokens.COMMA, ","),
-                (Tokens.STRING, "bool"),
-                (Tokens.COLON, ":"),
-                (Tokens.FALSE, "false"),
-                (Tokens.COMMA, ","),
-                (Tokens.STRING, "obj"),
-                (Tokens.COLON, ":"),
-                (Tokens.OPBRACE, "{"),
-                (Tokens.STRING, "inner"),
-                (Tokens.COLON, ":"),
-                (Tokens.STRING, "obj"),
-                (Tokens.CLBRACE, "}"),
-                (Tokens.COMMA, ","),
-                (Tokens.STRING, "arr"),
-                (Tokens.COLON, ":"),
-                (Tokens.OPBRACKET, "["),
-                (Tokens.STRING, "first"),
-                (Tokens.COMMA, ","),
-                (Tokens.NUMBER, "12"),
-                (Tokens.COMMA, ","),
-                (Tokens.TRUE, "true"),
-                (Tokens.CLBRACKET, "]"),
-                (Tokens.CLBRACE, "}"),
-                (Tokens.EOF, "")
+            (Tokens.OPBRACE, "{"),
+            (Tokens.STRING, "foo"),
+            (Tokens.COLON, ":"),
+            (Tokens.STRING, "bar"),
+            (Tokens.COMMA, ","),
+            (Tokens.STRING, "num"),
+            (Tokens.COLON, ":"),
+            (Tokens.NUMBER, "12"),
+            (Tokens.COMMA, ","),
+            (Tokens.STRING, "bool"),
+            (Tokens.COLON, ":"),
+            (Tokens.FALSE, "false"),
+            (Tokens.COMMA, ","),
+            (Tokens.STRING, "obj"),
+            (Tokens.COLON, ":"),
+            (Tokens.OPBRACE, "{"),
+            (Tokens.STRING, "inner"),
+            (Tokens.COLON, ":"),
+            (Tokens.STRING, "obj"),
+            (Tokens.CLBRACE, "}"),
+            (Tokens.COMMA, ","),
+            (Tokens.STRING, "arr"),
+            (Tokens.COLON, ":"),
+            (Tokens.OPBRACKET, "["),
+            (Tokens.STRING, "first"),
+            (Tokens.COMMA, ","),
+            (Tokens.NUMBER, "12"),
+            (Tokens.COMMA, ","),
+            (Tokens.TRUE, "true"),
+            (Tokens.CLBRACKET, "]"),
+            (Tokens.CLBRACE, "}"),
+            (Tokens.EOF, ""),
         ]
 
         lex = Lexer(json)
 
-        for expectedType, expectedLiteral in tokens:
+        for expected_type, expected_literal in tokens:
             tok = lex.nextToken()
 
-            self.assertEqual(expectedType, tok.type)
-            self.assertEqual(expectedLiteral, tok.literal)
+            self.assertEqual(expected_type, tok.type)
+            self.assertEqual(expected_literal, tok.literal)

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -3,6 +3,7 @@ import unittest
 from src.lexer import Lexer
 from src.parser import Parser
 
+
 class ParserTest(unittest.TestCase):
     def test_parsing(self):
         json = '{"foo":"bar", "num": 12, "bool": false, "obj": { "inner": "obj" }, "arr": ["first", 12, true]}'
@@ -11,13 +12,13 @@ class ParserTest(unittest.TestCase):
         parser = Parser(lex)
 
         data = parser.parse()
-        
-        expectedKeys = ["foo", "num", "bool", "obj", "arr"]
 
-        self.assertEqual(len(data.keys()), len(expectedKeys))
+        expected_keys = ["foo", "num", "bool", "obj", "arr"]
+
+        self.assertEqual(len(data.keys()), len(expected_keys))
 
         for key in data.keys():
-            self.assertIn(key, expectedKeys)
+            self.assertIn(key, expected_keys)
 
         self.assertEqual("inner" in data["obj"], True)
         self.assertEqual(True in data["arr"], True)


### PR DESCRIPTION
Rename function names to use the snake case convention:
`next_token()` instead `nextToken()`

Fix private method names. You must use a double underscore instead of one:
`__curr_token_is()` instead `_curr_token_is()`